### PR TITLE
Automatic support for RawRepresentable types

### DIFF
--- a/Cereal/CerealDecoder.swift
+++ b/Cereal/CerealDecoder.swift
@@ -60,6 +60,26 @@ public struct CerealDecoder {
     }
 
     /**
+     Decodes the `RawRepresentable` object contained in key.
+
+     This method is identical to `decode<DecodedType: CerealRepresentable>`, but may automatically decode
+     `RawRepresentable` types whose RawValue conforms `CerealRepresentable`.
+
+     - parameter    key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedType: RawRepresentable where DecodedType: CerealRepresentable, DecodedType.RawValue: CerealRepresentable>(key: String) throws -> DecodedType? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        guard let rawValue = try CerealDecoder.instantiate(data.value, ofType: data.type) as? DecodedType.RawValue else {
+            return nil
+        }
+        return DecodedType(rawValue: rawValue)
+    }
+
+    /**
     Decodes the object contained in key.
 
     This method can decode any type that conforms to `CerealType`.

--- a/Cereal/CerealEncoder.swift
+++ b/Cereal/CerealEncoder.swift
@@ -51,6 +51,18 @@ public struct CerealEncoder {
     }
 
     /**
+     Encodes an object conforming to `RawRepresentable` and `CerealRepresentable` (enums, OptionSetType etc) 
+     whose RawValue conforms to `CerealRepresentable` under `key`.
+
+     - parameter     item:    The object being encoded.
+     - parameter     key:     The key the object should be encoded under.
+     */
+    public mutating func encode<ItemType: RawRepresentable where ItemType: CerealRepresentable, ItemType.RawValue: CerealRepresentable>(item: ItemType?, forKey key: String) throws {
+        guard let unwrapped = item else { return }
+        items[key] = try encodeItem(unwrapped.rawValue)
+    }
+
+    /**
     Encodes an object conforming to `IdentifyingCerealType` under `key`.
 
     - parameter     item:    The object being encoded.

--- a/CerealTests/CerealDecoderTests.swift
+++ b/CerealTests/CerealDecoderTests.swift
@@ -162,6 +162,28 @@ class CerealDecoderTests: XCTestCase {
         }
     }
 
+    // MARK: RawRepresentable
+
+    func testDecodingStringEnum() {
+        do {
+            let subject = try CerealDecoder(encodedString: "k,8:enumtest:s,9:TestCase2")
+            let resultEnum: TestEnum = try subject.decode("enumtest") ?? .TestCase1
+            XCTAssertEqual(resultEnum, TestEnum.TestCase2)
+        } catch let error {
+            XCTFail("Decoding failed due to error: \(error)")
+        }
+    }
+
+    func testDecodingIntOptionSet() {
+        do {
+            let subject = try CerealDecoder(encodedString: "k,13:optionsettest:i,1:3")
+            let resultOptions: TestSetType = try subject.decode("optionsettest") ?? []
+            XCTAssertEqual(resultOptions, [TestSetType.FirstOption, TestSetType.SecondOption])
+        } catch let error {
+            XCTFail("Decoding failed due to error: \(error)")
+        }
+    }
+
     // MARK: - Custom Types
 
     func testDecoding_withCereal() {

--- a/CerealTests/CerealEncoderTests.swift
+++ b/CerealTests/CerealEncoderTests.swift
@@ -287,7 +287,32 @@ class CerealEncoderTests: XCTestCase {
             XCTFail("Encoding failed due to error: \(error)")
         }
     }
-    
+
+    // MARK: RawRepresentable
+
+    func testToString_withStringEnum() {
+        var subject = CerealEncoder()
+        do {
+            try subject.encode(TestEnum.TestCase2, forKey: "myenum")
+            let result = subject.toString()
+            XCTAssertEqual(result, "k,6:myenum:s,9:TestCase2")
+        } catch let error {
+            XCTFail("Encoding failed due to error: \(error)")
+        }
+    }
+
+    func testToString_withIntOptionSet() {
+        var subject = CerealEncoder()
+        do {
+            let options: TestSetType = [TestSetType.FirstOption, TestSetType.SecondOption]
+            try subject.encode(options, forKey: "myoptionset")
+            let result = subject.toString()
+            XCTAssertEqual(result, "k,11:myoptionset:i,1:3")
+        } catch let error {
+            XCTFail("Encoding failed due to error: \(error)")
+        }
+    }
+
     // MARK: - Custom Types
 
     func testToString_withCereal() {

--- a/CerealTests/TestTypes.swift
+++ b/CerealTests/TestTypes.swift
@@ -199,3 +199,21 @@ struct MyBaz: Bazable {
 // Extending objects with CerealRepresentable is not supported, so this will be used to test
 // that if it is, the correct error is used.
 extension NSData: CerealRepresentable { }
+
+enum TestEnum: String {
+    case TestCase1
+    case TestCase2
+}
+
+extension TestEnum: CerealRepresentable { }
+
+struct TestSetType : OptionSetType {
+    let rawValue: Int
+
+    static let None         = TestSetType(rawValue: 0)
+    static let FirstOption  = TestSetType(rawValue: 1 << 0)
+    static let SecondOption = TestSetType(rawValue: 1 << 1)
+    static let ThirdOption  = TestSetType(rawValue: 1 << 2)
+}
+
+extension TestSetType: CerealRepresentable { }


### PR DESCRIPTION
This pull request allows to shorten existing code for enums or `OptionSetType`, or any type that conforms to `RawRepresentable` protocol.
With this we no longer need to write code like this:

``` swift
enum Gender: Int {
    case Female
    case Male
}

extension Gender: CerealType {
    private struct Keys {
        static let root = "gender"
    }

    init(decoder: CerealDecoder) throws {
        self.init(rawValue: try decoder.decode(Keys.root) ?? Gender.Female.rawValue)!
    }

    func encodeWithCereal(inout cereal: CerealEncoder) throws {
        try cereal.encode(rawValue, forKey: Keys.root)
    }
}
```

Instead we could write it like this:

``` swift
enum Gender: Int {
    case Female
    case Male
}

extension Gender: CerealRepresentable {}
```

No force unwrapping, it just works.
Now all you need is encode or decode enum variable just like a `String` or `Int` type:

``` swift
gender = try cereal.decode(Keys.gender) ?? .Female
try cereal.encode(gender, forKey: Keys.gender)
```
