### PR TITLE
More support for RawRepresentable (dictionaries, arrays)

### DIFF
--- a/Cereal/CerealDecoder.swift
+++ b/Cereal/CerealDecoder.swift
@@ -60,24 +60,6 @@ public struct CerealDecoder {
     }
 
     /**
-     Decodes the `RawRepresentable` object contained in key.
-
-     This method is identical to `decode<DecodedType: CerealRepresentable>`, but may automatically decode
-     `RawRepresentable` types whose RawValue conforms `CerealRepresentable`.
-
-     - parameter    key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decode<DecodedType: protocol<RawRepresentable, CerealRepresentable> where DecodedType.RawValue: CerealRepresentable>(key: String) throws -> DecodedType? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        let decodedResult: DecodedType = try CerealDecoder.instantiate(data.value, ofType: data.type)
-        return decodedResult
-    }
-
-    /**
     Decodes the object contained in key.
 
     This method can decode any type that conforms to `CerealType`.
@@ -128,28 +110,6 @@ public struct CerealDecoder {
     - returns:      The instantiated object, or nil if no object was at the specified key.
     */
     public func decode<DecodedType: CerealRepresentable>(key: String) throws -> [DecodedType]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        return try CerealDecoder.parseEncodedArrayString(data.value)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes homogeneous arrays of type `DecodedType`, where `DecodedType`
-     conforms to `CerealRepresentable`.
-
-     This method does not support decoding `CerealType` objects, but
-     can decode `IndentifyingCerealType` objects.
-
-     If you are decoding a `IdentifyingCerealType` it must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decode<DecodedType: protocol<RawRepresentable, CerealRepresentable> where DecodedType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedType]? {
         guard let data = items[key] else {
             return nil
         }
@@ -236,62 +196,6 @@ public struct CerealDecoder {
 
         return decodedItems
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealRepresentable`
-     and a value conforming to `CerealRepresentable`.
-
-     This method does not support decoding `CerealType` objects, but
-     can decode `IdentifyingCerealType` objects.
-
-     If you are decoding a `IdentifyingCerealType` it must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealRepresentable where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: DecodedValueType]]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        var decodedItems = [[DecodedKeyType: DecodedValueType]]()
-
-        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
-            decodedItems.append(try CerealDecoder.parseEncodedDictionaryString(value))
-        }
-
-        return decodedItems
-    }
-    /**
-     `RawRepresentable` function overload for both key and value conforming to `RawRepresentable`
-
-     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealRepresentable`
-     and a value conforming to `CerealRepresentable`.
-
-     This method does not support decoding `CerealType` objects, but
-     can decode `IdentifyingCerealType` objects.
-
-     If you are decoding a `IdentifyingCerealType` it must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable, DecodedValueType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: DecodedValueType]]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        var decodedItems = [[DecodedKeyType: DecodedValueType]]()
-
-        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
-            decodedItems.append(try CerealDecoder.parseEncodedDictionaryString(value))
-        }
-
-        return decodedItems
-    }
 
     /**
     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealRepresentable`
@@ -307,34 +211,6 @@ public struct CerealDecoder {
     - returns:      The instantiated object, or nil if no object was at the specified key.
     */
     public func decodeCereal<DecodedKeyType: protocol<CerealRepresentable, Hashable>, DecodedValueType: CerealType>(key: String) throws -> [[DecodedKeyType: DecodedValueType]]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        var decodedItems = [[DecodedKeyType: DecodedValueType]]()
-
-        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
-            decodedItems.append(try CerealDecoder.parseEncodedCerealDictionaryString(value))
-        }
-
-        return decodedItems
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealRepresentable`
-     and a value conforming to `CerealType`.
-
-     This method does not support decoding `CerealType` objects for its key, but
-     can decode `IdentifyingCerealType` objects.
-
-     If you are decoding a `IdentifyingCerealType` for the key it must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decodeCereal<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealType where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: DecodedValueType]]? {
         guard let data = items[key] else {
             return nil
         }
@@ -374,34 +250,6 @@ public struct CerealDecoder {
         
         return decodedItems
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealType`
-     and a value conforming to `CerealRepresentable`.
-
-     This method does not support decoding `CerealType` objects for its value, but
-     can decode `IdentifyingCerealType` objects.
-
-     If you are decoding a `IdentifyingCerealType` it must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decodeCereal<DecodedKeyType: protocol<CerealType, Hashable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedValueType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: DecodedValueType]]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        var decodedItems = [[DecodedKeyType: DecodedValueType]]()
-
-        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
-            decodedItems.append(try CerealDecoder.parseEncodedCerealDictionaryString(value))
-        }
-
-        return decodedItems
-    }
 
     /**
     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealType`
@@ -439,34 +287,6 @@ public struct CerealDecoder {
     - returns:      The instantiated object, or nil if no object was at the specified key.
     */
     public func decodeIdentifyingCerealArray<DecodedKeyType: protocol<CerealRepresentable, Hashable>>(key: String) throws -> [[DecodedKeyType: IdentifyingCerealType]]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        var decodedItems = [[DecodedKeyType: IdentifyingCerealType]]()
-        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
-            decodedItems.append(try CerealDecoder.parseEncodedIdentifyingCerealDictionaryString(value))
-        }
-
-        return decodedItems
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes heterogenous arrays containing dictionaries that have a key conforming to `CerealRepresentable`
-     and a value conforming to `IdentifyingCerealType`.
-
-     This method does not support decoding `CerealType` objects for its key, but
-     can decode `IdentifyingCerealType` objects.
-
-     If you are decoding a `IdentifyingCerealType` for the key it must be registered
-     before calling this method. The `IdentifyingCerealType` must be registered
-     for the value before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decodeIdentifyingCerealArray<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: IdentifyingCerealType]]? {
         guard let data = items[key] else {
             return nil
         }
@@ -521,44 +341,6 @@ public struct CerealDecoder {
 
         return try CerealDecoder.parseEncodedDictionaryString(data.value)
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes homogeneous dictoinaries conforming to `CerealRepresentable` for both the key
-     and value.
-
-     This method does not support decoding `CerealType` objects, but
-     can decode `IdentifyingCerealType` objects.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealRepresentable where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: DecodedValueType]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        return try CerealDecoder.parseEncodedDictionaryString(data.value)
-    }
-    /**
-     `RawRepresentable` function overload for both key and value conforming to `RawRepresentable`
-
-     Decodes homogeneous dictoinaries conforming to `CerealRepresentable` for both the key
-     and value.
-
-     This method does not support decoding `CerealType` objects, but
-     can decode `IdentifyingCerealType` objects.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable, DecodedValueType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: DecodedValueType]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        return try CerealDecoder.parseEncodedDictionaryString(data.value)
-    }
 
     /**
     Decodes heterogeneous values conforming to `CerealRepresentable`. 
@@ -571,25 +353,6 @@ public struct CerealDecoder {
     - returns:      The instantiated object, or nil if no object was at the specified key.
     */
     public func decode<DecodedKeyType: protocol<CerealRepresentable, Hashable>>(key: String) throws -> [DecodedKeyType: CerealRepresentable]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        return try CerealDecoder.parseEncodedDictionaryString(data.value)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes heterogeneous values conforming to `CerealRepresentable`.
-     They key must be homogeneous.
-
-     This method does not support decoding `CerealType` objects, but
-     can decode `IdentifyingCerealType` objects.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: CerealRepresentable]? {
         guard let data = items[key] else {
             return nil
         }
@@ -611,28 +374,6 @@ public struct CerealDecoder {
     - returns:      The instantiated object, or nil if no object was at the specified key.
     */
     public func decodeCereal<DecodedKeyType: protocol<CerealRepresentable, Hashable>, DecodedValueType: CerealType>(key: String) throws -> [DecodedKeyType: DecodedValueType]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        return try CerealDecoder.parseEncodedCerealDictionaryString(data.value)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes homogenous values conforming to `CerealType` and keys conforming to
-     `CerealRepresentable`.
-
-     This method does not support decoding `CerealType` objects, but
-     can decode `IdentifyingCerealType` objects.
-
-     The `IdentifyingCerealType` for the value must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decodeCereal<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealType where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: DecodedValueType]? {
         guard let data = items[key] else {
             return nil
         }
@@ -678,25 +419,6 @@ public struct CerealDecoder {
 
         return try CerealDecoder.parseEncodedIdentifyingCerealDictionaryString(data.value)
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes homogenous values conforming to `CerealRepresentable` and keys conforming to
-     `IdentifyingCerealType`.
-
-     The `IdentifyingCerealType` for the value must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decodeIdentifyingCerealDictionary<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: IdentifyingCerealType]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        return try CerealDecoder.parseEncodedIdentifyingCerealDictionaryString(data.value)
-    }
 
     /**
     Decodes homogenous keys and values conforming to `CerealType`.
@@ -731,6 +453,7 @@ public struct CerealDecoder {
     }
 
     // MARK: Dictionaries of Arrays
+
     /**
     Decodes a homogenous dictionary of arrays conforming to `CerealRepresentable`. The key
     must be a `CerealRepresentable`.
@@ -745,64 +468,6 @@ public struct CerealDecoder {
     - returns:      The instantiated object, or nil if no object was at the specified key.
     */
     public func decode<DecodedKeyType: protocol<CerealRepresentable, Hashable>, DecodedValueType: CerealRepresentable>(key: String) throws -> [DecodedKeyType: [DecodedValueType]]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        var decodedItems = [DecodedKeyType: [DecodedValueType]]()
-
-        try data.value.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
-            decodedItems[decodedKey] = try CerealDecoder.parseEncodedArrayString(value)
-        }
-
-        return decodedItems
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes a homogenous dictionary of arrays conforming to `CerealRepresentable`. The key
-     must be a `CerealRepresentable`.
-
-     This method does not support decoding `CerealType` objects, but
-     can decode `IdentifyingCerealType` objects.
-
-     The `IdentifyingCerealType` for the value must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealRepresentable where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: [DecodedValueType]]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        var decodedItems = [DecodedKeyType: [DecodedValueType]]()
-
-        try data.value.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
-            decodedItems[decodedKey] = try CerealDecoder.parseEncodedArrayString(value)
-        }
-
-        return decodedItems
-    }
-    /**
-     `RawRepresentable` function overload for both key and value conforming to `RawRepresentable`
-
-     Decodes a homogenous dictionary of arrays conforming to `CerealRepresentable`. The key
-     must be a `CerealRepresentable`.
-
-     This method does not support decoding `CerealType` objects, but
-     can decode `IdentifyingCerealType` objects.
-
-     The `IdentifyingCerealType` for the value must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable, DecodedValueType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: [DecodedValueType]]? {
         guard let data = items[key] else {
             return nil
         }
@@ -842,35 +507,6 @@ public struct CerealDecoder {
             decodedItems[decodedKey] = try CerealDecoder.parseEncodedCerealArrayString(value)
         }
         
-        return decodedItems
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes a homogenous dictionary of arrays conforming to `CerealType`. The key
-     must be a `CerealRepresentable`.
-
-     This method does not support decoding `CerealType` keys, but
-     can decode `IdentifyingCerealType` keys.
-
-     The `IdentifyingCerealType` for the key must be registered
-     before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decodeCereal<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealType where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: [DecodedValueType]]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        var decodedItems = [DecodedKeyType: [DecodedValueType]]()
-
-        try data.value.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
-            decodedItems[decodedKey] = try CerealDecoder.parseEncodedCerealArrayString(value)
-        }
-
         return decodedItems
     }
 
@@ -939,36 +575,6 @@ public struct CerealDecoder {
     - returns:      The instantiated object, or nil if no object was at the specified key.
     */
     public func decodeIdentifyingCerealDictionary<DecodedKeyType: protocol<CerealRepresentable, Hashable>>(key: String) throws -> [DecodedKeyType: [IdentifyingCerealType]]? {
-        guard let data = items[key] else {
-            return nil
-        }
-
-        var decodedItems = [DecodedKeyType: [IdentifyingCerealType]]()
-
-        try data.value.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
-            decodedItems[decodedKey] = try CerealDecoder.parseEncodedIdentifyingCerealArrayString(value)
-        }
-
-        return decodedItems
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes a heterogenous dictionary of arrays conforming to `IdentifyingCerealType`. The key
-     must be a `CerealRepresentable`.
-
-     This method does not support decoding `CerealType` keys, but
-     can decode `IdentifyingCerealType` keys.
-
-     The `IdentifyingCerealType` for the value must be registered
-     before calling this method. If using an `IdentifyingCerealType` for the
-     key it must also be registered before calling this method.
-
-     - parameter     key:     The key that the object being decoded resides at.
-     - returns:      The instantiated object, or nil if no object was at the specified key.
-     */
-    public func decodeIdentifyingCerealDictionary<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: [IdentifyingCerealType]]? {
         guard let data = items[key] else {
             return nil
         }
@@ -1291,41 +897,6 @@ public struct CerealDecoder {
         guard let item: [ItemKeyType: [ItemValueType]] = try decoder.decode(rootKey) else { throw CerealError.RootItemNotFound }
         return item
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes objects encoded with `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
-
-     If you encoded custom objects for your values or keys conforming to `CerealType`, use `CerealDecoder.rootCerealItemsWithData` instead.
-
-     If you encoded custom objects for your values and keys conforming to `CerealType`, use `CerealDecoder.rootCerealPairItemsWithData` instead.
-
-     - parameter     data:    The data returned by `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
-     - returns:       The instantiated object.
-     */
-    public static func rootItemsWithData<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(data: NSData) throws -> [ItemKeyType: [ItemValueType]] {
-        let decoder = try CerealDecoder(data: data)
-        guard let item: [ItemKeyType: [ItemValueType]] = try decoder.decode(rootKey) else { throw CerealError.RootItemNotFound }
-        return item
-    }
-    /**
-     `RawRepresentable` function overload for both key and value conforming to `RawRepresentable`
-
-
-     Decodes objects encoded with `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
-
-     If you encoded custom objects for your values or keys conforming to `CerealType`, use `CerealDecoder.rootCerealItemsWithData` instead.
-
-     If you encoded custom objects for your values and keys conforming to `CerealType`, use `CerealDecoder.rootCerealPairItemsWithData` instead.
-
-     - parameter     data:    The data returned by `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
-     - returns:       The instantiated object.
-     */
-    public static func rootItemsWithData<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(data: NSData) throws -> [ItemKeyType: [ItemValueType]] {
-        let decoder = try CerealDecoder(data: data)
-        guard let item: [ItemKeyType: [ItemValueType]] = try decoder.decode(rootKey) else { throw CerealError.RootItemNotFound }
-        return item
-    }
 
     /**
     Decodes objects encoded with `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
@@ -1336,21 +907,6 @@ public struct CerealDecoder {
     - returns:      The instantiated object.
     */
     public static func rootCerealItemsWithData<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealType>(data: NSData) throws -> [ItemKeyType: [ItemValueType]] {
-        let decoder = try CerealDecoder(data: data)
-        guard let item: [ItemKeyType: [ItemValueType]] = try decoder.decodeCereal(rootKey) else { throw CerealError.RootItemNotFound }
-        return item
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes objects encoded with `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
-
-     If you encoded custom objects for your keys conforming to `CerealType`, use `CerealDecoder.rootCerealPairItemsWithData` instead.
-
-     - parameter     data:    The data returned by `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
-     - returns:      The instantiated object.
-     */
-    public static func rootCerealItemsWithData<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealType where ItemKeyType.RawValue: CerealRepresentable>(data: NSData) throws -> [ItemKeyType: [ItemValueType]] {
         let decoder = try CerealDecoder(data: data)
         guard let item: [ItemKeyType: [ItemValueType]] = try decoder.decodeCereal(rootKey) else { throw CerealError.RootItemNotFound }
         return item
@@ -1394,24 +950,6 @@ public struct CerealDecoder {
     - returns:       The instantiated object.
     */
     public static func rootIdentifyingCerealItemsWithData<ItemKeyType: protocol<CerealRepresentable, Hashable>>(data: NSData) throws -> [ItemKeyType: [IdentifyingCerealType]] {
-        let decoder = try CerealDecoder(data: data)
-        guard let item: [ItemKeyType: [IdentifyingCerealType]] = try decoder.decodeIdentifyingCerealDictionary(rootKey) else { throw CerealError.RootItemNotFound }
-        return item
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Decodes objects encoded with `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [ItemKeyType: [IdentifyingCerealType]])`.
-
-     If you encoded custom objects for your keys conforming to `CerealType`, use `CerealDecoder.rootCerealToIdentifyingCerealItemsWithData` instead.
-
-     The `IdentifyingCerealType` for the returned object must be registered
-     before calling this method.
-
-     - parameter     data:    The data returned by `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [ItemKeyType: [IdentifyingCerealType]])`.
-     - returns:       The instantiated object.
-     */
-    public static func rootIdentifyingCerealItemsWithData<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(data: NSData) throws -> [ItemKeyType: [IdentifyingCerealType]] {
         let decoder = try CerealDecoder(data: data)
         guard let item: [ItemKeyType: [IdentifyingCerealType]] = try decoder.decodeIdentifyingCerealDictionary(rootKey) else { throw CerealError.RootItemNotFound }
         return item
@@ -1548,14 +1086,6 @@ public struct CerealDecoder {
 
         return decodedResult
     }
-    private static func instantiate<T: RawRepresentable where T: CerealRepresentable, T.RawValue: CerealRepresentable>(value: String, ofType type: CerealTypeIdentifier) throws -> T {
-        guard let rawValue = try CerealDecoder.instantiate(value, ofType: type) as? T.RawValue, let decodedResult = T(rawValue: rawValue) else {
-            throw CerealError.InvalidEncoding("Failed to decode value \(value) with type \(type)")
-        }
-
-        return decodedResult
-    }
-
 
     /// Used for CerealType where we have type data from the compiler
     private static func instantiateCereal<DecodedType: CerealType>(value: String, ofType type: CerealTypeIdentifier) throws -> DecodedType {
@@ -1659,16 +1189,6 @@ public struct CerealDecoder {
 
         return decodedItems
     }
-    private static func parseEncodedArrayString<DecodedType: RawRepresentable where DecodedType: CerealRepresentable, DecodedType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedType] {
-        var decodedItems = [DecodedType]()
-
-        try encodedString.iterateEncodedValuesWithInstantationHandler { type, value in
-            let decodedValue: DecodedType = try CerealDecoder.instantiate(value, ofType: type)
-            decodedItems.append(decodedValue)
-        }
-
-        return decodedItems
-    }
 
     private static func parseEncodedCerealArrayString<DecodedType: CerealType>(encodedString: String) throws -> [DecodedType] {
         var decodedItems = [DecodedType]()
@@ -1697,39 +1217,8 @@ public struct CerealDecoder {
 
         return decodedItems
     }
-    private static func parseEncodedDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: CerealRepresentable] {
-        var decodedItems = [DecodedKeyType: CerealRepresentable]()
-        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
-            decodedItems[decodedKey] = try CerealDecoder.instantiate(value, ofType: type)
-        }
-
-        return decodedItems
-    }
 
     private static func parseEncodedDictionaryString<DecodedKeyType: protocol<Hashable, CerealRepresentable>, DecodedValueType: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
-        var decodedItems = [DecodedKeyType: DecodedValueType]()
-        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
-            let decodedValue: DecodedValueType = try CerealDecoder.instantiate(value, ofType: type)
-
-            decodedItems[decodedKey] = decodedValue
-        }
-
-        return decodedItems
-    }
-    private static func parseEncodedDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable>, DecodedValueType: CerealRepresentable where DecodedKeyType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
-        var decodedItems = [DecodedKeyType: DecodedValueType]()
-        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
-            let decodedValue: DecodedValueType = try CerealDecoder.instantiate(value, ofType: type)
-
-            decodedItems[decodedKey] = decodedValue
-        }
-
-        return decodedItems
-    }
-    private static func parseEncodedDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable, DecodedValueType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
         var decodedItems = [DecodedKeyType: DecodedValueType]()
         try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
             let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
@@ -1750,28 +1239,8 @@ public struct CerealDecoder {
 
         return decodedItems
     }
-    private static func parseEncodedCerealDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable>, DecodedValueType: CerealType where DecodedKeyType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
-        var decodedItems = [DecodedKeyType: DecodedValueType]()
-        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
-            decodedItems[decodedKey] = try CerealDecoder.instantiateCereal(value, ofType: type) as DecodedValueType
-        }
-
-        return decodedItems
-    }
 
     private static func parseEncodedCerealDictionaryString<DecodedKeyType: protocol<Hashable, CerealType>, DecodedValueType: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
-        var decodedItems = [DecodedKeyType: DecodedValueType]()
-        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiateCereal(keyValue, ofType: keyType)
-            let decodedValue: DecodedValueType = try CerealDecoder.instantiate(value, ofType: type)
-
-            decodedItems[decodedKey] = decodedValue
-        }
-
-        return decodedItems
-    }
-    private static func parseEncodedCerealDictionaryString<DecodedKeyType: protocol<Hashable, CerealType>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedValueType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
         var decodedItems = [DecodedKeyType: DecodedValueType]()
         try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
             let decodedKey: DecodedKeyType = try CerealDecoder.instantiateCereal(keyValue, ofType: keyType)
@@ -1804,15 +1273,6 @@ public struct CerealDecoder {
 
         return decodedItem
     }
-    private static func parseEncodedIdentifyingCerealDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: IdentifyingCerealType] {
-        var decodedItem = [DecodedKeyType: IdentifyingCerealType]()
-        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
-            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
-            decodedItem[decodedKey] = try CerealDecoder.instantiateIdentifyingCereal(value)
-        }
-
-        return decodedItem
-    }
 
     private static func parseEncodedCerealToIdentifyingCerealDictionaryString<DecodedKeyType: protocol<Hashable, CerealType>>(encodedString: String) throws -> [DecodedKeyType: IdentifyingCerealType] {
         var decodedItem = [DecodedKeyType: IdentifyingCerealType]()
@@ -1825,6 +1285,571 @@ public struct CerealDecoder {
     }
 }
 
+// MARK: - RawRepresentable overrides -
+
+extension CerealDecoder {
+    // MARK: - Decoding
+
+    /**
+     Decodes the object contained in key.
+
+     This method can decode any of the structs conforming to `CerealRepresentable` or
+     any type that conforms to `IdentifyingCerealType`. If the type conforms to
+     `IdentifyingCerealType` it must be registered with Cereal before calling
+     this method.
+
+     - parameter    key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedType: protocol<RawRepresentable, CerealRepresentable> where DecodedType.RawValue: CerealRepresentable>(key: String) throws -> DecodedType? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        let decodedResult: DecodedType = try CerealDecoder.instantiate(data.value, ofType: data.type)
+        return decodedResult
+    }
+
+    // MARK: Arrays
+
+    /**
+     Decodes homogeneous arrays of type `DecodedType`, where `DecodedType`
+     conforms to `CerealRepresentable`.
+
+     This method does not support decoding `CerealType` objects, but
+     can decode `IndentifyingCerealType` objects.
+
+     If you are decoding a `IdentifyingCerealType` it must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedType: protocol<RawRepresentable, CerealRepresentable> where DecodedType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedType]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        return try CerealDecoder.parseEncodedArrayString(data.value)
+    }
+
+    // MARK: Arrays of Dictionaries
+
+    /**
+     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealRepresentable`
+     and a value conforming to `CerealRepresentable`.
+
+     This method does not support decoding `CerealType` objects, but
+     can decode `IdentifyingCerealType` objects.
+
+     If you are decoding a `IdentifyingCerealType` it must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealRepresentable where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: DecodedValueType]]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        var decodedItems = [[DecodedKeyType: DecodedValueType]]()
+
+        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
+            decodedItems.append(try CerealDecoder.parseEncodedDictionaryString(value))
+        }
+
+        return decodedItems
+    }
+
+    /**
+     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealRepresentable`
+     and a value conforming to `CerealRepresentable`.
+
+     This method does not support decoding `CerealType` objects, but
+     can decode `IdentifyingCerealType` objects.
+
+     If you are decoding a `IdentifyingCerealType` it must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable, DecodedValueType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: DecodedValueType]]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        var decodedItems = [[DecodedKeyType: DecodedValueType]]()
+
+        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
+            decodedItems.append(try CerealDecoder.parseEncodedDictionaryString(value))
+        }
+        
+        return decodedItems
+    }
+
+    /**
+     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealRepresentable`
+     and a value conforming to `CerealType`.
+
+     This method does not support decoding `CerealType` objects for its key, but
+     can decode `IdentifyingCerealType` objects.
+
+     If you are decoding a `IdentifyingCerealType` for the key it must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decodeCereal<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealType where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: DecodedValueType]]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        var decodedItems = [[DecodedKeyType: DecodedValueType]]()
+
+        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
+            decodedItems.append(try CerealDecoder.parseEncodedCerealDictionaryString(value))
+        }
+        
+        return decodedItems
+    }
+
+    /**
+     Decodes homogenous arrays containing dictionaries that have a key conforming to `CerealType`
+     and a value conforming to `CerealRepresentable`.
+
+     This method does not support decoding `CerealType` objects for its value, but
+     can decode `IdentifyingCerealType` objects.
+
+     If you are decoding a `IdentifyingCerealType` it must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decodeCereal<DecodedKeyType: protocol<CerealType, Hashable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedValueType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: DecodedValueType]]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        var decodedItems = [[DecodedKeyType: DecodedValueType]]()
+
+        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
+            decodedItems.append(try CerealDecoder.parseEncodedCerealDictionaryString(value))
+        }
+        
+        return decodedItems
+    }
+
+    // MARK: Dictionaries
+
+    /**
+     Decodes homogeneous dictoinaries conforming to `CerealRepresentable` for both the key
+     and value.
+
+     This method does not support decoding `CerealType` objects, but
+     can decode `IdentifyingCerealType` objects.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealRepresentable where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: DecodedValueType]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        return try CerealDecoder.parseEncodedDictionaryString(data.value)
+    }
+    /**
+     Decodes homogeneous dictoinaries conforming to `CerealRepresentable` for both the key
+     and value.
+
+     This method does not support decoding `CerealType` objects, but
+     can decode `IdentifyingCerealType` objects.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable, DecodedValueType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: DecodedValueType]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        return try CerealDecoder.parseEncodedDictionaryString(data.value)
+    }
+
+    /**
+     Decodes heterogeneous values conforming to `CerealRepresentable`.
+     They key must be homogeneous.
+
+     This method does not support decoding `CerealType` objects, but
+     can decode `IdentifyingCerealType` objects.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: CerealRepresentable]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        return try CerealDecoder.parseEncodedDictionaryString(data.value)
+    }
+
+    /**
+     Decodes homogenous values conforming to `CerealType` and keys conforming to
+     `CerealRepresentable`.
+
+     This method does not support decoding `CerealType` objects, but
+     can decode `IdentifyingCerealType` objects.
+
+     The `IdentifyingCerealType` for the value must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decodeCereal<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealType where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: DecodedValueType]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        return try CerealDecoder.parseEncodedCerealDictionaryString(data.value)
+    }
+
+    /**
+     Decodes homogenous values conforming to `CerealRepresentable` and keys conforming to
+     `IdentifyingCerealType`.
+
+     The `IdentifyingCerealType` for the value must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decodeIdentifyingCerealDictionary<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: IdentifyingCerealType]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        return try CerealDecoder.parseEncodedIdentifyingCerealDictionaryString(data.value)
+    }
+
+    // MARK: Dictionaries of Arrays
+
+    /**
+     Decodes a homogenous dictionary of arrays conforming to `CerealRepresentable`. The key
+     must be a `CerealRepresentable`.
+
+     This method does not support decoding `CerealType` objects, but
+     can decode `IdentifyingCerealType` objects.
+
+     The `IdentifyingCerealType` for the value must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealRepresentable where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: [DecodedValueType]]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        var decodedItems = [DecodedKeyType: [DecodedValueType]]()
+
+        try data.value.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
+            decodedItems[decodedKey] = try CerealDecoder.parseEncodedArrayString(value)
+        }
+
+        return decodedItems
+    }
+
+    /**
+     Decodes a homogenous dictionary of arrays conforming to `CerealRepresentable`. The key
+     must be a `CerealRepresentable`.
+
+     This method does not support decoding `CerealType` objects, but
+     can decode `IdentifyingCerealType` objects.
+
+     The `IdentifyingCerealType` for the value must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decode<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable, DecodedValueType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: [DecodedValueType]]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        var decodedItems = [DecodedKeyType: [DecodedValueType]]()
+
+        try data.value.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
+            decodedItems[decodedKey] = try CerealDecoder.parseEncodedArrayString(value)
+        }
+        
+        return decodedItems
+    }
+
+    /**
+     Decodes a homogenous dictionary of arrays conforming to `CerealType`. The key
+     must be a `CerealRepresentable`.
+
+     This method does not support decoding `CerealType` keys, but
+     can decode `IdentifyingCerealType` keys.
+
+     The `IdentifyingCerealType` for the key must be registered
+     before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decodeCereal<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, DecodedValueType: CerealType where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: [DecodedValueType]]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        var decodedItems = [DecodedKeyType: [DecodedValueType]]()
+
+        try data.value.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
+            decodedItems[decodedKey] = try CerealDecoder.parseEncodedCerealArrayString(value)
+        }
+        
+        return decodedItems
+    }
+
+    /**
+     Decodes a heterogenous dictionary of arrays conforming to `IdentifyingCerealType`. The key
+     must be a `CerealRepresentable`.
+
+     This method does not support decoding `CerealType` keys, but
+     can decode `IdentifyingCerealType` keys.
+
+     The `IdentifyingCerealType` for the value must be registered
+     before calling this method. If using an `IdentifyingCerealType` for the
+     key it must also be registered before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decodeIdentifyingCerealDictionary<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [DecodedKeyType: [IdentifyingCerealType]]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        var decodedItems = [DecodedKeyType: [IdentifyingCerealType]]()
+
+        try data.value.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
+            decodedItems[decodedKey] = try CerealDecoder.parseEncodedIdentifyingCerealArrayString(value)
+        }
+        
+        return decodedItems
+    }
+
+    // MARK: - Root Decoding
+
+    // These methods are convenience methods that allow users to quickly decode their object.
+
+    // MARK: Arrays of Dictionaries
+
+    /**
+     Decodes objects encoded with `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
+
+     If you encoded custom objects for your values or keys conforming to `CerealType`, use `CerealDecoder.rootCerealItemsWithData` instead.
+
+     If you encoded custom objects for your values and keys conforming to `CerealType`, use `CerealDecoder.rootCerealPairItemsWithData` instead.
+
+     - parameter     data:    The data returned by `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
+     - returns:       The instantiated object.
+     */
+    public static func rootItemsWithData<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(data: NSData) throws -> [ItemKeyType: [ItemValueType]] {
+        let decoder = try CerealDecoder(data: data)
+        guard let item: [ItemKeyType: [ItemValueType]] = try decoder.decode(rootKey) else { throw CerealError.RootItemNotFound }
+        return item
+    }
+
+    /**
+     Decodes objects encoded with `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
+
+     If you encoded custom objects for your values or keys conforming to `CerealType`, use `CerealDecoder.rootCerealItemsWithData` instead.
+
+     If you encoded custom objects for your values and keys conforming to `CerealType`, use `CerealDecoder.rootCerealPairItemsWithData` instead.
+
+     - parameter     data:    The data returned by `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
+     - returns:       The instantiated object.
+     */
+    public static func rootItemsWithData<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(data: NSData) throws -> [ItemKeyType: [ItemValueType]] {
+        let decoder = try CerealDecoder(data: data)
+        guard let item: [ItemKeyType: [ItemValueType]] = try decoder.decode(rootKey) else { throw CerealError.RootItemNotFound }
+        return item
+    }
+
+    /**
+     Decodes objects encoded with `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
+
+     If you encoded custom objects for your keys conforming to `CerealType`, use `CerealDecoder.rootCerealPairItemsWithData` instead.
+
+     - parameter     data:    The data returned by `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]])`.
+     - returns:      The instantiated object.
+     */
+    public static func rootCerealItemsWithData<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealType where ItemKeyType.RawValue: CerealRepresentable>(data: NSData) throws -> [ItemKeyType: [ItemValueType]] {
+        let decoder = try CerealDecoder(data: data)
+        guard let item: [ItemKeyType: [ItemValueType]] = try decoder.decodeCereal(rootKey) else { throw CerealError.RootItemNotFound }
+        return item
+    }
+
+    // MARK: Dictionaries of Arrays
+
+    /**
+     Decodes objects encoded with `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [ItemKeyType: [IdentifyingCerealType]])`.
+
+     If you encoded custom objects for your keys conforming to `CerealType`, use `CerealDecoder.rootCerealToIdentifyingCerealItemsWithData` instead.
+
+     The `IdentifyingCerealType` for the returned object must be registered
+     before calling this method.
+
+     - parameter     data:    The data returned by `CerealEncoder.dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [ItemKeyType: [IdentifyingCerealType]])`.
+     - returns:       The instantiated object.
+     */
+    public static func rootIdentifyingCerealItemsWithData<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(data: NSData) throws -> [ItemKeyType: [IdentifyingCerealType]] {
+        let decoder = try CerealDecoder(data: data)
+        guard let item: [ItemKeyType: [IdentifyingCerealType]] = try decoder.decodeIdentifyingCerealDictionary(rootKey) else { throw CerealError.RootItemNotFound }
+        return item
+    }
+
+    // MARK: Arrays of Dictionaries
+
+    /**
+     Decodes heterogenous arrays containing dictionaries that have a key conforming to `CerealRepresentable`
+     and a value conforming to `IdentifyingCerealType`.
+
+     This method does not support decoding `CerealType` objects for its key, but
+     can decode `IdentifyingCerealType` objects.
+
+     If you are decoding a `IdentifyingCerealType` for the key it must be registered
+     before calling this method. The `IdentifyingCerealType` must be registered
+     for the value before calling this method.
+
+     - parameter     key:     The key that the object being decoded resides at.
+     - returns:      The instantiated object, or nil if no object was at the specified key.
+     */
+    public func decodeIdentifyingCerealArray<DecodedKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where DecodedKeyType.RawValue: CerealRepresentable>(key: String) throws -> [[DecodedKeyType: IdentifyingCerealType]]? {
+        guard let data = items[key] else {
+            return nil
+        }
+
+        var decodedItems = [[DecodedKeyType: IdentifyingCerealType]]()
+        try data.value.iterateEncodedValuesWithInstantationHandler { type, value in
+            decodedItems.append(try CerealDecoder.parseEncodedIdentifyingCerealDictionaryString(value))
+        }
+
+        return decodedItems
+    }
+}
+
+// MARK: - RawRepresentable private functions overrides -
+
+private extension CerealDecoder {
+    // MARK: - Instantiators
+    // Instantiators take a String and type information, either through a CerealTypeIdentifier or a Generic, and instantiate the object
+    // being asked for
+
+    /// Used for primitive or identifying cereal values
+
+    private static func instantiate<T: RawRepresentable where T: CerealRepresentable, T.RawValue: CerealRepresentable>(value: String, ofType type: CerealTypeIdentifier) throws -> T {
+        guard let rawValue = try CerealDecoder.instantiate(value, ofType: type) as? T.RawValue, let decodedResult = T(rawValue: rawValue) else {
+            throw CerealError.InvalidEncoding("Failed to decode value \(value) with type \(type)")
+        }
+
+        return decodedResult
+    }
+
+    // MARK: - Parsers
+    
+    private static func parseEncodedArrayString<DecodedType: RawRepresentable where DecodedType: CerealRepresentable, DecodedType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedType] {
+        var decodedItems = [DecodedType]()
+
+        try encodedString.iterateEncodedValuesWithInstantationHandler { type, value in
+            let decodedValue: DecodedType = try CerealDecoder.instantiate(value, ofType: type)
+            decodedItems.append(decodedValue)
+        }
+
+        return decodedItems
+    }
+
+    private static func parseEncodedDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: CerealRepresentable] {
+        var decodedItems = [DecodedKeyType: CerealRepresentable]()
+        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
+            decodedItems[decodedKey] = try CerealDecoder.instantiate(value, ofType: type)
+        }
+
+        return decodedItems
+    }
+
+    private static func parseEncodedDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable>, DecodedValueType: CerealRepresentable where DecodedKeyType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
+        var decodedItems = [DecodedKeyType: DecodedValueType]()
+        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
+            let decodedValue: DecodedValueType = try CerealDecoder.instantiate(value, ofType: type)
+
+            decodedItems[decodedKey] = decodedValue
+        }
+
+        return decodedItems
+    }
+
+    private static func parseEncodedDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable, DecodedValueType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
+        var decodedItems = [DecodedKeyType: DecodedValueType]()
+        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
+            let decodedValue: DecodedValueType = try CerealDecoder.instantiate(value, ofType: type)
+
+            decodedItems[decodedKey] = decodedValue
+        }
+
+        return decodedItems
+    }
+
+    private static func parseEncodedCerealDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable>, DecodedValueType: CerealType where DecodedKeyType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
+        var decodedItems = [DecodedKeyType: DecodedValueType]()
+        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
+            decodedItems[decodedKey] = try CerealDecoder.instantiateCereal(value, ofType: type) as DecodedValueType
+        }
+
+        return decodedItems
+    }
+
+    private static func parseEncodedCerealDictionaryString<DecodedKeyType: protocol<Hashable, CerealType>, DecodedValueType: protocol<RawRepresentable, CerealRepresentable> where DecodedValueType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: DecodedValueType] {
+        var decodedItems = [DecodedKeyType: DecodedValueType]()
+        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, type, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiateCereal(keyValue, ofType: keyType)
+            let decodedValue: DecodedValueType = try CerealDecoder.instantiate(value, ofType: type)
+
+            decodedItems[decodedKey] = decodedValue
+        }
+
+        return decodedItems
+    }
+
+    private static func parseEncodedIdentifyingCerealDictionaryString<DecodedKeyType: protocol<RawRepresentable, Hashable, CerealRepresentable> where DecodedKeyType.RawValue: CerealRepresentable>(encodedString: String) throws -> [DecodedKeyType: IdentifyingCerealType] {
+        var decodedItem = [DecodedKeyType: IdentifyingCerealType]()
+        try encodedString.iterateEncodedValuesWithInstantationHandler { keyType, keyValue, _, value in
+            let decodedKey: DecodedKeyType = try CerealDecoder.instantiate(keyValue, ofType: keyType)
+            decodedItem[decodedKey] = try CerealDecoder.instantiateIdentifyingCereal(value)
+        }
+
+        return decodedItem
+    }
+
+}
 
 extension String {
     func iterateEncodedValuesWithInstantationHandler(instantiationHandler: (type: CerealTypeIdentifier, value: String) throws -> Void) throws {

--- a/Cereal/CerealEncoder.swift
+++ b/Cereal/CerealEncoder.swift
@@ -57,9 +57,9 @@ public struct CerealEncoder {
      - parameter     item:    The object being encoded.
      - parameter     key:     The key the object should be encoded under.
      */
-    public mutating func encode<ItemType: RawRepresentable where ItemType: CerealRepresentable, ItemType.RawValue: CerealRepresentable>(item: ItemType?, forKey key: String) throws {
+    public mutating func encode<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(item: ItemType?, forKey key: String) throws {
         guard let unwrapped = item else { return }
-        items[key] = try encodeItem(unwrapped.rawValue)
+        items[key] = try encodeItem(unwrapped)
     }
 
     /**
@@ -82,6 +82,18 @@ public struct CerealEncoder {
     - parameter     key:     The key the objects should be encoded under.
     */
     public mutating func encode<ItemType: CerealRepresentable>(items: [ItemType]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes an array of objects conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The objects being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(items: [ItemType]?, forKey key: String) throws {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
@@ -109,6 +121,30 @@ public struct CerealEncoder {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes an array of dictionaries where the key and value conform to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionaries being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes an array of dictionaries where the key and value conform to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionaries being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
 
     /**
     Encodes an array of dictionaries where the keys conform to `CerealRepresentable` and values conform to `IdentifyingCerealType` object under `key`.
@@ -117,6 +153,18 @@ public struct CerealEncoder {
     - parameter     key:     The key the objects should be encoded under.
     */
     public mutating func encodeIdentifyingItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [[ItemKeyType: IdentifyingCerealType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes an array of dictionaries where the keys conform to `CerealRepresentable` and values conform to `IdentifyingCerealType` object under `key`.
+
+     - parameter     items:   The dictionaries being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: IdentifyingCerealType]]?, forKey key: String) throws {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
@@ -133,6 +181,30 @@ public struct CerealEncoder {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys and values conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys and values conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
 
     /**
     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` object under `key`.
@@ -141,6 +213,18 @@ public struct CerealEncoder {
     - parameter     key:     The key the objects should be encoded under.
     */
     public mutating func encodeIdentifyingItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [ItemKeyType: IdentifyingCerealType]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeIdentifyingItems(unwrapped)
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: IdentifyingCerealType]?, forKey key: String) throws {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeIdentifyingItems(unwrapped)
     }
@@ -157,6 +241,30 @@ public struct CerealEncoder {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys and arrays of values conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys and arrays of values conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
 
     /**
     Encodes a dictionary of keys conforming to `CerealRepresentable` and arrays of values conforming to `IdentifyingCerealType` object under `key`.
@@ -165,6 +273,18 @@ public struct CerealEncoder {
     - parameter     key     The key the objects should be encoded under.
     */
     public mutating func encodeIdentifyingItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [ItemKeyType: [IdentifyingCerealType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeIdentifyingItems(unwrapped)
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys conforming to `CerealRepresentable` and arrays of values conforming to `IdentifyingCerealType` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key     The key the objects should be encoded under.
+     */
+    public mutating func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [IdentifyingCerealType]]?, forKey key: String) throws {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeIdentifyingItems(unwrapped)
     }
@@ -182,6 +302,19 @@ public struct CerealEncoder {
     - returns:      The object encoded as an `NSData`
     */
     public static func dataWithRootItem<ItemType: CerealRepresentable>(root: ItemType) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes an object conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The object being encoded.
+     - returns:      The object encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(root: ItemType) throws -> NSData {
         var encoder = CerealEncoder()
         try encoder.encode(root, forKey: rootKey)
         return encoder.toData()
@@ -212,6 +345,19 @@ public struct CerealEncoder {
         try encoder.encode(root, forKey: rootKey)
         return encoder.toData()
     }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes an array of objects conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(root: [ItemType]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
 
     /**
     Encodes an array of objects conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
@@ -238,6 +384,32 @@ public struct CerealEncoder {
         try encoder.encode(root, forKey: rootKey)
         return encoder.toData()
     }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes an array of dictionaries of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(root: [[ItemKeyType: ItemValueType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes an array of dictionaries of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(root: [[ItemKeyType: ItemValueType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
 
     /**
     Encodes an array of dictionaries of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
@@ -246,6 +418,19 @@ public struct CerealEncoder {
     - returns:      The objects encoded as an `NSData`
     */
     public static func dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [[ItemKeyType: IdentifyingCerealType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encodeIdentifyingItems(root, forKey: rootKey)
+        return encoder.toData()
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes an array of dictionaries of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(root: [[ItemKeyType: IdentifyingCerealType]]) throws -> NSData {
         var encoder = CerealEncoder()
         try encoder.encodeIdentifyingItems(root, forKey: rootKey)
         return encoder.toData()
@@ -264,6 +449,32 @@ public struct CerealEncoder {
         try encoder.encode(root, forKey: rootKey)
         return encoder.toData()
     }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: ItemValueType]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(root: [ItemKeyType: ItemValueType]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
 
     /**
     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conform to `IdentifyingCerealType` and returns an `NSData` object representing it.
@@ -272,6 +483,20 @@ public struct CerealEncoder {
     - returns:      The objects encoded as an `NSData`
     */
     public static func dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [ItemKeyType: IdentifyingCerealType]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encodeIdentifyingItems(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conform to `IdentifyingCerealType` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: IdentifyingCerealType]) throws -> NSData {
         var encoder = CerealEncoder()
         try encoder.encodeIdentifyingItems(root, forKey: rootKey)
         return encoder.toData()
@@ -292,12 +517,53 @@ public struct CerealEncoder {
     }
 
     /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys and array of values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    /**
+     `RawRepresentable` function overload.
+
+     Encodes a dictionary of keys and array of values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    /**
     Encodes a dictionary of keys of keys conforming to `CerealRepresentable` and array values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
 
     - parameter     item:    The objects being encoded.
     - returns:      The objects encoded as an `NSData`
     */
     public static func dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [ItemKeyType: [IdentifyingCerealType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encodeIdentifyingItems(root, forKey: rootKey)
+        return encoder.toData()
+    }
+    /**
+     `RawRepresentable` function overload. 
+
+     Encodes a dictionary of keys of keys conforming to `CerealRepresentable` and array values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: [IdentifyingCerealType]]) throws -> NSData {
         var encoder = CerealEncoder()
         try encoder.encodeIdentifyingItems(root, forKey: rootKey)
         return encoder.toData()
@@ -352,6 +618,9 @@ public struct CerealEncoder {
         default: throw CerealError.UnsupportedCerealRepresentable("Item \(item) not supported)")
         }
     }
+    private func encodeItem<ItemType: RawRepresentable where ItemType: CerealRepresentable, ItemType.RawValue: CerealRepresentable>(item: ItemType) throws -> String {
+        return try self.encodeItem(item.rawValue)
+    }
 
     private func encodeItem(item: IdentifyingCerealType) throws -> String {
         var cereal = CerealEncoder()
@@ -369,6 +638,17 @@ public struct CerealEncoder {
     // MARK: Arrays of Dictionaries
 
     private func encodeItems<ItemType: CerealRepresentable>(items: [ItemType]) throws -> String {
+        var encodedArrayItems = [String]()
+
+        for obj in items {
+            encodedArrayItems.append(try encodeItem(obj))
+        }
+
+        let combined = encodedArrayItems.joinWithSeparator(":")
+
+        return "a,\(combined.characters.count):\(combined)"
+    }
+    private func encodeItems<ItemType: RawRepresentable where ItemType: CerealRepresentable, ItemType.RawValue: CerealRepresentable>(items: [ItemType]) throws -> String {
         var encodedArrayItems = [String]()
 
         for obj in items {
@@ -403,8 +683,41 @@ public struct CerealEncoder {
 
         return "a,\(combined.characters.count):\(combined)"
     }
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]) throws-> String {
+        var encodedArrayItems = [String]()
+
+        for obj in items {
+            encodedArrayItems.append(try encodeItems(obj))
+        }
+
+        let combined = encodedArrayItems.joinWithSeparator(":")
+
+        return "a,\(combined.characters.count):\(combined)"
+    }
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]) throws-> String {
+        var encodedArrayItems = [String]()
+
+        for obj in items {
+            encodedArrayItems.append(try encodeItems(obj))
+        }
+
+        let combined = encodedArrayItems.joinWithSeparator(":")
+
+        return "a,\(combined.characters.count):\(combined)"
+    }
 
     private func encodeItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [[ItemKeyType: IdentifyingCerealType]]) throws-> String {
+        var encodedArrayItems = [String]()
+
+        for obj in items {
+            encodedArrayItems.append(try encodeItems(obj))
+        }
+
+        let combined = encodedArrayItems.joinWithSeparator(":")
+
+        return "a,\(combined.characters.count):\(combined)"
+    }
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: IdentifyingCerealType]]) throws-> String {
         var encodedArrayItems = [String]()
 
         for obj in items {
@@ -431,6 +744,32 @@ public struct CerealEncoder {
 
         return "m,\(combined.characters.count):\(combined)"
     }
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItem(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItem(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
 
     private func encodeItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [ItemKeyType: IdentifyingCerealType]) throws -> String {
         var encodedDictionaryItems = [String]()
@@ -445,8 +784,34 @@ public struct CerealEncoder {
 
         return "m,\(combined.characters.count):\(combined)"
     }
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: IdentifyingCerealType]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItem(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
 
     private func encodeIdentifyingItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [ItemKeyType: IdentifyingCerealType]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItem(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
+    private func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: IdentifyingCerealType]) throws -> String {
         var encodedDictionaryItems = [String]()
 
         for (key, value) in items {
@@ -474,6 +839,32 @@ public struct CerealEncoder {
 
         return "m,\(combined.characters.count):\(combined)"
     }
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItems(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItems(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
 
     private func encodeIdentifyingItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [ItemKeyType: [IdentifyingCerealType]]) throws -> String {
         var encodedDictionaryItems = [String]()
@@ -485,8 +876,20 @@ public struct CerealEncoder {
         }
 
         let combined = encodedDictionaryItems.joinWithSeparator(":")
-
+        
         return "m,\(combined.characters.count):\(combined)"
     }
-
+    private func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [IdentifyingCerealType]]) throws -> String {
+        var encodedDictionaryItems = [String]()
+        
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeIdentifyingItems(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+        
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+        
+        return "m,\(combined.characters.count):\(combined)"
+    }
 }

--- a/Cereal/CerealEncoder.swift
+++ b/Cereal/CerealEncoder.swift
@@ -51,18 +51,6 @@ public struct CerealEncoder {
     }
 
     /**
-     Encodes an object conforming to `RawRepresentable` and `CerealRepresentable` (enums, OptionSetType etc) 
-     whose RawValue conforms to `CerealRepresentable` under `key`.
-
-     - parameter     item:    The object being encoded.
-     - parameter     key:     The key the object should be encoded under.
-     */
-    public mutating func encode<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(item: ItemType?, forKey key: String) throws {
-        guard let unwrapped = item else { return }
-        items[key] = try encodeItem(unwrapped)
-    }
-
-    /**
     Encodes an object conforming to `IdentifyingCerealType` under `key`.
 
     - parameter     item:    The object being encoded.
@@ -82,18 +70,6 @@ public struct CerealEncoder {
     - parameter     key:     The key the objects should be encoded under.
     */
     public mutating func encode<ItemType: CerealRepresentable>(items: [ItemType]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeItems(unwrapped)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes an array of objects conforming to `CerealRepresentable` object under `key`.
-
-     - parameter     items:   The objects being encoded.
-     - parameter     key:     The key the objects should be encoded under.
-     */
-    public mutating func encode<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(items: [ItemType]?, forKey key: String) throws {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
@@ -121,30 +97,6 @@ public struct CerealEncoder {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes an array of dictionaries where the key and value conform to `CerealRepresentable` object under `key`.
-
-     - parameter     items:   The dictionaries being encoded.
-     - parameter     key:     The key the objects should be encoded under.
-     */
-    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeItems(unwrapped)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes an array of dictionaries where the key and value conform to `CerealRepresentable` object under `key`.
-
-     - parameter     items:   The dictionaries being encoded.
-     - parameter     key:     The key the objects should be encoded under.
-     */
-    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeItems(unwrapped)
-    }
 
     /**
     Encodes an array of dictionaries where the keys conform to `CerealRepresentable` and values conform to `IdentifyingCerealType` object under `key`.
@@ -153,18 +105,6 @@ public struct CerealEncoder {
     - parameter     key:     The key the objects should be encoded under.
     */
     public mutating func encodeIdentifyingItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [[ItemKeyType: IdentifyingCerealType]]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeItems(unwrapped)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes an array of dictionaries where the keys conform to `CerealRepresentable` and values conform to `IdentifyingCerealType` object under `key`.
-
-     - parameter     items:   The dictionaries being encoded.
-     - parameter     key:     The key the objects should be encoded under.
-     */
-    public mutating func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: IdentifyingCerealType]]?, forKey key: String) throws {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
@@ -181,30 +121,6 @@ public struct CerealEncoder {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys and values conforming to `CerealRepresentable` object under `key`.
-
-     - parameter     items:   The dictionary being encoded.
-     - parameter     key:     The key the objects should be encoded under.
-     */
-    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeItems(unwrapped)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys and values conforming to `CerealRepresentable` object under `key`.
-
-     - parameter     items:   The dictionary being encoded.
-     - parameter     key:     The key the objects should be encoded under.
-     */
-    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeItems(unwrapped)
-    }
 
     /**
     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` object under `key`.
@@ -213,18 +129,6 @@ public struct CerealEncoder {
     - parameter     key:     The key the objects should be encoded under.
     */
     public mutating func encodeIdentifyingItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [ItemKeyType: IdentifyingCerealType]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeIdentifyingItems(unwrapped)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` object under `key`.
-
-     - parameter     items:   The dictionary being encoded.
-     - parameter     key:     The key the objects should be encoded under.
-     */
-    public mutating func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: IdentifyingCerealType]?, forKey key: String) throws {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeIdentifyingItems(unwrapped)
     }
@@ -241,30 +145,6 @@ public struct CerealEncoder {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeItems(unwrapped)
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys and arrays of values conforming to `CerealRepresentable` object under `key`.
-
-     - parameter     items:   The dictionary being encoded.
-     - parameter     key:     The key the objects should be encoded under.
-     */
-    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeItems(unwrapped)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys and arrays of values conforming to `CerealRepresentable` object under `key`.
-
-     - parameter     items:   The dictionary being encoded.
-     - parameter     key:     The key the objects should be encoded under.
-     */
-    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeItems(unwrapped)
-    }
 
     /**
     Encodes a dictionary of keys conforming to `CerealRepresentable` and arrays of values conforming to `IdentifyingCerealType` object under `key`.
@@ -273,18 +153,6 @@ public struct CerealEncoder {
     - parameter     key     The key the objects should be encoded under.
     */
     public mutating func encodeIdentifyingItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [ItemKeyType: [IdentifyingCerealType]]?, forKey key: String) throws {
-        guard let unwrapped = items else { return }
-        self.items[key] = try encodeIdentifyingItems(unwrapped)
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys conforming to `CerealRepresentable` and arrays of values conforming to `IdentifyingCerealType` object under `key`.
-
-     - parameter     items:   The dictionary being encoded.
-     - parameter     key     The key the objects should be encoded under.
-     */
-    public mutating func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [IdentifyingCerealType]]?, forKey key: String) throws {
         guard let unwrapped = items else { return }
         self.items[key] = try encodeIdentifyingItems(unwrapped)
     }
@@ -302,19 +170,6 @@ public struct CerealEncoder {
     - returns:      The object encoded as an `NSData`
     */
     public static func dataWithRootItem<ItemType: CerealRepresentable>(root: ItemType) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encode(root, forKey: rootKey)
-        return encoder.toData()
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes an object conforming to `CerealRepresentable` and returns an `NSData` object representing it.
-
-     - parameter     item:    The object being encoded.
-     - returns:      The object encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(root: ItemType) throws -> NSData {
         var encoder = CerealEncoder()
         try encoder.encode(root, forKey: rootKey)
         return encoder.toData()
@@ -345,19 +200,6 @@ public struct CerealEncoder {
         try encoder.encode(root, forKey: rootKey)
         return encoder.toData()
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes an array of objects conforming to `CerealRepresentable` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(root: [ItemType]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encode(root, forKey: rootKey)
-        return encoder.toData()
-    }
 
     /**
     Encodes an array of objects conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
@@ -384,32 +226,6 @@ public struct CerealEncoder {
         try encoder.encode(root, forKey: rootKey)
         return encoder.toData()
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes an array of dictionaries of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(root: [[ItemKeyType: ItemValueType]]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encode(root, forKey: rootKey)
-        return encoder.toData()
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes an array of dictionaries of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(root: [[ItemKeyType: ItemValueType]]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encode(root, forKey: rootKey)
-        return encoder.toData()
-    }
 
     /**
     Encodes an array of dictionaries of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
@@ -418,19 +234,6 @@ public struct CerealEncoder {
     - returns:      The objects encoded as an `NSData`
     */
     public static func dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [[ItemKeyType: IdentifyingCerealType]]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encodeIdentifyingItems(root, forKey: rootKey)
-        return encoder.toData()
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes an array of dictionaries of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(root: [[ItemKeyType: IdentifyingCerealType]]) throws -> NSData {
         var encoder = CerealEncoder()
         try encoder.encodeIdentifyingItems(root, forKey: rootKey)
         return encoder.toData()
@@ -449,32 +252,6 @@ public struct CerealEncoder {
         try encoder.encode(root, forKey: rootKey)
         return encoder.toData()
     }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: ItemValueType]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encode(root, forKey: rootKey)
-        return encoder.toData()
-    }
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(root: [ItemKeyType: ItemValueType]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encode(root, forKey: rootKey)
-        return encoder.toData()
-    }
 
     /**
     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conform to `IdentifyingCerealType` and returns an `NSData` object representing it.
@@ -483,20 +260,6 @@ public struct CerealEncoder {
     - returns:      The objects encoded as an `NSData`
     */
     public static func dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [ItemKeyType: IdentifyingCerealType]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encodeIdentifyingItems(root, forKey: rootKey)
-        return encoder.toData()
-    }
-
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conform to `IdentifyingCerealType` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: IdentifyingCerealType]) throws -> NSData {
         var encoder = CerealEncoder()
         try encoder.encodeIdentifyingItems(root, forKey: rootKey)
         return encoder.toData()
@@ -517,53 +280,12 @@ public struct CerealEncoder {
     }
 
     /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys and array of values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encode(root, forKey: rootKey)
-        return encoder.toData()
-    }
-
-    /**
-     `RawRepresentable` function overload.
-
-     Encodes a dictionary of keys and array of values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encode(root, forKey: rootKey)
-        return encoder.toData()
-    }
-
-    /**
     Encodes a dictionary of keys of keys conforming to `CerealRepresentable` and array values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
 
     - parameter     item:    The objects being encoded.
     - returns:      The objects encoded as an `NSData`
     */
     public static func dataWithRootItem<ItemKeyType: protocol<CerealRepresentable, Hashable>>(root: [ItemKeyType: [IdentifyingCerealType]]) throws -> NSData {
-        var encoder = CerealEncoder()
-        try encoder.encodeIdentifyingItems(root, forKey: rootKey)
-        return encoder.toData()
-    }
-    /**
-     `RawRepresentable` function overload. 
-
-     Encodes a dictionary of keys of keys conforming to `CerealRepresentable` and array values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
-
-     - parameter     item:    The objects being encoded.
-     - returns:      The objects encoded as an `NSData`
-     */
-    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: [IdentifyingCerealType]]) throws -> NSData {
         var encoder = CerealEncoder()
         try encoder.encodeIdentifyingItems(root, forKey: rootKey)
         return encoder.toData()
@@ -618,9 +340,6 @@ public struct CerealEncoder {
         default: throw CerealError.UnsupportedCerealRepresentable("Item \(item) not supported)")
         }
     }
-    private func encodeItem<ItemType: RawRepresentable where ItemType: CerealRepresentable, ItemType.RawValue: CerealRepresentable>(item: ItemType) throws -> String {
-        return try self.encodeItem(item.rawValue)
-    }
 
     private func encodeItem(item: IdentifyingCerealType) throws -> String {
         var cereal = CerealEncoder()
@@ -638,17 +357,6 @@ public struct CerealEncoder {
     // MARK: Arrays of Dictionaries
 
     private func encodeItems<ItemType: CerealRepresentable>(items: [ItemType]) throws -> String {
-        var encodedArrayItems = [String]()
-
-        for obj in items {
-            encodedArrayItems.append(try encodeItem(obj))
-        }
-
-        let combined = encodedArrayItems.joinWithSeparator(":")
-
-        return "a,\(combined.characters.count):\(combined)"
-    }
-    private func encodeItems<ItemType: RawRepresentable where ItemType: CerealRepresentable, ItemType.RawValue: CerealRepresentable>(items: [ItemType]) throws -> String {
         var encodedArrayItems = [String]()
 
         for obj in items {
@@ -683,41 +391,8 @@ public struct CerealEncoder {
 
         return "a,\(combined.characters.count):\(combined)"
     }
-    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]) throws-> String {
-        var encodedArrayItems = [String]()
-
-        for obj in items {
-            encodedArrayItems.append(try encodeItems(obj))
-        }
-
-        let combined = encodedArrayItems.joinWithSeparator(":")
-
-        return "a,\(combined.characters.count):\(combined)"
-    }
-    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]) throws-> String {
-        var encodedArrayItems = [String]()
-
-        for obj in items {
-            encodedArrayItems.append(try encodeItems(obj))
-        }
-
-        let combined = encodedArrayItems.joinWithSeparator(":")
-
-        return "a,\(combined.characters.count):\(combined)"
-    }
 
     private func encodeItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [[ItemKeyType: IdentifyingCerealType]]) throws-> String {
-        var encodedArrayItems = [String]()
-
-        for obj in items {
-            encodedArrayItems.append(try encodeItems(obj))
-        }
-
-        let combined = encodedArrayItems.joinWithSeparator(":")
-
-        return "a,\(combined.characters.count):\(combined)"
-    }
-    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: IdentifyingCerealType]]) throws-> String {
         var encodedArrayItems = [String]()
 
         for obj in items {
@@ -744,47 +419,8 @@ public struct CerealEncoder {
 
         return "m,\(combined.characters.count):\(combined)"
     }
-    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]) throws -> String {
-        var encodedDictionaryItems = [String]()
-
-        for (key, value) in items {
-            let encodedKey = try encodeItem(key)
-            let encodedValue = try encodeItem(value)
-            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
-        }
-
-        let combined = encodedDictionaryItems.joinWithSeparator(":")
-
-        return "m,\(combined.characters.count):\(combined)"
-    }
-    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]) throws -> String {
-        var encodedDictionaryItems = [String]()
-
-        for (key, value) in items {
-            let encodedKey = try encodeItem(key)
-            let encodedValue = try encodeItem(value)
-            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
-        }
-
-        let combined = encodedDictionaryItems.joinWithSeparator(":")
-
-        return "m,\(combined.characters.count):\(combined)"
-    }
 
     private func encodeItems<ItemKeyType: protocol<CerealRepresentable, Hashable>>(items: [ItemKeyType: IdentifyingCerealType]) throws -> String {
-        var encodedDictionaryItems = [String]()
-
-        for (key, value) in items {
-            let encodedKey = try encodeItem(key)
-            let encodedValue = try encodeItem(value)
-            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
-        }
-
-        let combined = encodedDictionaryItems.joinWithSeparator(":")
-
-        return "m,\(combined.characters.count):\(combined)"
-    }
-    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: IdentifyingCerealType]) throws -> String {
         var encodedDictionaryItems = [String]()
 
         for (key, value) in items {
@@ -811,48 +447,10 @@ public struct CerealEncoder {
 
         return "m,\(combined.characters.count):\(combined)"
     }
-    private func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: IdentifyingCerealType]) throws -> String {
-        var encodedDictionaryItems = [String]()
-
-        for (key, value) in items {
-            let encodedKey = try encodeItem(key)
-            let encodedValue = try encodeItem(value)
-            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
-        }
-
-        let combined = encodedDictionaryItems.joinWithSeparator(":")
-
-        return "m,\(combined.characters.count):\(combined)"
-    }
 
     // MARK: Dictionaries of Arrays
+
     private func encodeItems<ItemKeyType: protocol<CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]) throws -> String {
-        var encodedDictionaryItems = [String]()
-
-        for (key, value) in items {
-            let encodedKey = try encodeItem(key)
-            let encodedValue = try encodeItems(value)
-            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
-        }
-
-        let combined = encodedDictionaryItems.joinWithSeparator(":")
-
-        return "m,\(combined.characters.count):\(combined)"
-    }
-    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]) throws -> String {
-        var encodedDictionaryItems = [String]()
-
-        for (key, value) in items {
-            let encodedKey = try encodeItem(key)
-            let encodedValue = try encodeItems(value)
-            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
-        }
-
-        let combined = encodedDictionaryItems.joinWithSeparator(":")
-
-        return "m,\(combined.characters.count):\(combined)"
-    }
-    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]) throws -> String {
         var encodedDictionaryItems = [String]()
 
         for (key, value) in items {
@@ -879,17 +477,452 @@ public struct CerealEncoder {
         
         return "m,\(combined.characters.count):\(combined)"
     }
+}
+
+// MARK: - RawRepresentable overrides -
+
+extension CerealEncoder {
+
+    // MARK: - Single items
+
+    /**
+     Encodes an object conforming to `RawRepresentable` and `CerealRepresentable` (enums, OptionSetType etc)
+     whose RawValue conforms to `CerealRepresentable` under `key`.
+
+     - parameter     item:    The object being encoded.
+     - parameter     key:     The key the object should be encoded under.
+     */
+    public mutating func encode<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(item: ItemType?, forKey key: String) throws {
+        guard let unwrapped = item else { return }
+        items[key] = try encodeItem(unwrapped)
+    }
+
+    // MARK: - Arrays
+
+    /**
+     Encodes an array of objects conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The objects being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(items: [ItemType]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+
+    // MARK: Arrays of Dictionaries
+
+    /**
+     Encodes an array of dictionaries where the key and value conform to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionaries being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+
+    /**
+     Encodes an array of dictionaries where the key and value conform to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionaries being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+
+    /**
+     Encodes an array of dictionaries where the keys conform to `CerealRepresentable` and values conform to `IdentifyingCerealType` object under `key`.
+
+     - parameter     items:   The dictionaries being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: IdentifyingCerealType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+
+    // MARK: - Dictionaries
+
+    /**
+     Encodes a dictionary of keys and values conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+
+    /**
+     Encodes a dictionary of keys and values conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+
+    /**
+     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: IdentifyingCerealType]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeIdentifyingItems(unwrapped)
+    }
+
+    // MARK: Dictionaries of Arrays
+
+    /**
+     Encodes a dictionary of keys and arrays of values conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+    /**
+     Encodes a dictionary of keys and arrays of values conforming to `CerealRepresentable` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key:     The key the objects should be encoded under.
+     */
+    public mutating func encode<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeItems(unwrapped)
+    }
+
+    /**
+     Encodes a dictionary of keys conforming to `CerealRepresentable` and arrays of values conforming to `IdentifyingCerealType` object under `key`.
+
+     - parameter     items:   The dictionary being encoded.
+     - parameter     key     The key the objects should be encoded under.
+     */
+    public mutating func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [IdentifyingCerealType]]?, forKey key: String) throws {
+        guard let unwrapped = items else { return }
+        self.items[key] = try encodeIdentifyingItems(unwrapped)
+    }
+
+    // MARK: - Root encoding
+
+    // These methods are convenience methods that allow users to quickly encode their object into what they will be stored as.
+
+    // MARK: Basic items
+
+    /**
+     Encodes an object conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The object being encoded.
+     - returns:      The object encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(root: ItemType) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    // MARK: Arrays
+
+    /**
+     Encodes an array of objects conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemType: protocol<RawRepresentable, CerealRepresentable> where ItemType.RawValue: CerealRepresentable>(root: [ItemType]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    // MARK: Arrays of Dictionaries
+    
+    /**
+     Encodes an array of dictionaries of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(root: [[ItemKeyType: ItemValueType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    /**
+     Encodes an array of dictionaries of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(root: [[ItemKeyType: ItemValueType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+    
+    /**
+     Encodes an array of dictionaries of keys conforming to `CerealRepresentable` and values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(root: [[ItemKeyType: IdentifyingCerealType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encodeIdentifyingItems(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    // MARK: Dictionaries
+
+    /**
+     Encodes a dictionary of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: ItemValueType]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+    /**
+     Encodes a dictionary of keys and values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(root: [ItemKeyType: ItemValueType]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    /**
+     Encodes a dictionary of keys conforming to `CerealRepresentable` and values conform to `IdentifyingCerealType` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: IdentifyingCerealType]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encodeIdentifyingItems(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    // MARK: Dictionaries of Arrays
+
+    /**
+     Encodes a dictionary of keys and array of values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    /**
+     Encodes a dictionary of keys and array of values conforming to `CerealRepresentable` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(root: [ItemKeyType: [ItemValueType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encode(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    /**
+     Encodes a dictionary of keys of keys conforming to `CerealRepresentable` and array values conforming to `IdentifyingCerealType` and returns an `NSData` object representing it.
+
+     - parameter     item:    The objects being encoded.
+     - returns:      The objects encoded as an `NSData`
+     */
+    public static func dataWithRootItem<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(root: [ItemKeyType: [IdentifyingCerealType]]) throws -> NSData {
+        var encoder = CerealEncoder()
+        try encoder.encodeIdentifyingItems(root, forKey: rootKey)
+        return encoder.toData()
+    }
+
+    // MARK: - Encoding
+
+    // MARK: Basic
+
+    private func encodeItem<ItemType: RawRepresentable where ItemType: CerealRepresentable, ItemType.RawValue: CerealRepresentable>(item: ItemType) throws -> String {
+        return try self.encodeItem(item.rawValue)
+    }
+
+    // MARK: Arrays of Dictionaries
+
+    private func encodeItems<ItemType: RawRepresentable where ItemType: CerealRepresentable, ItemType.RawValue: CerealRepresentable>(items: [ItemType]) throws -> String {
+        var encodedArrayItems = [String]()
+
+        for obj in items {
+            encodedArrayItems.append(try encodeItem(obj))
+        }
+
+        let combined = encodedArrayItems.joinWithSeparator(":")
+
+        return "a,\(combined.characters.count):\(combined)"
+    }
+}
+
+// MARK: - RawRepresentable private functions overrides -
+
+private extension CerealEncoder {
+
+    // MARK: Arrays of Dictionaries
+
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]) throws-> String {
+        var encodedArrayItems = [String]()
+
+        for obj in items {
+            encodedArrayItems.append(try encodeItems(obj))
+        }
+
+        let combined = encodedArrayItems.joinWithSeparator(":")
+
+        return "a,\(combined.characters.count):\(combined)"
+    }
+
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [[ItemKeyType: ItemValueType]]) throws-> String {
+        var encodedArrayItems = [String]()
+
+        for obj in items {
+            encodedArrayItems.append(try encodeItems(obj))
+        }
+
+        let combined = encodedArrayItems.joinWithSeparator(":")
+
+        return "a,\(combined.characters.count):\(combined)"
+    }
+
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [[ItemKeyType: IdentifyingCerealType]]) throws-> String {
+        var encodedArrayItems = [String]()
+
+        for obj in items {
+            encodedArrayItems.append(try encodeItems(obj))
+        }
+
+        let combined = encodedArrayItems.joinWithSeparator(":")
+
+        return "a,\(combined.characters.count):\(combined)"
+    }
+
+    // MARK: Dictionaries
+
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItem(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
+
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: ItemValueType]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItem(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
+
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: IdentifyingCerealType]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItem(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
+
+    private func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: IdentifyingCerealType]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItem(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
+
+    // MARK: Dictionaries of Arrays
+
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: CerealRepresentable where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItems(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
+
+    private func encodeItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable>, ItemValueType: protocol<RawRepresentable, CerealRepresentable> where ItemKeyType.RawValue: CerealRepresentable, ItemValueType.RawValue: CerealRepresentable>(items: [ItemKeyType: [ItemValueType]]) throws -> String {
+        var encodedDictionaryItems = [String]()
+
+        for (key, value) in items {
+            let encodedKey = try encodeItem(key)
+            let encodedValue = try encodeItems(value)
+            encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
+        }
+
+        let combined = encodedDictionaryItems.joinWithSeparator(":")
+
+        return "m,\(combined.characters.count):\(combined)"
+    }
+
     private func encodeIdentifyingItems<ItemKeyType: protocol<RawRepresentable, CerealRepresentable, Hashable> where ItemKeyType.RawValue: CerealRepresentable>(items: [ItemKeyType: [IdentifyingCerealType]]) throws -> String {
         var encodedDictionaryItems = [String]()
-        
+
         for (key, value) in items {
             let encodedKey = try encodeItem(key)
             let encodedValue = try encodeIdentifyingItems(value)
             encodedDictionaryItems.append("\(encodedKey):\(encodedValue)")
         }
-        
+
         let combined = encodedDictionaryItems.joinWithSeparator(":")
-        
+
         return "m,\(combined.characters.count):\(combined)"
     }
 }

--- a/CerealTests/CerealDecoderDictionaryTests.swift
+++ b/CerealTests/CerealDecoderDictionaryTests.swift
@@ -714,6 +714,33 @@ class CerealDecoderDictionaryTests: XCTestCase {
         }
     }
 
+    // MARK: [RawRepresentable: XYZ]
+    func testDecoding_withStringEnumToIntDictionary() {
+        do {
+            let subject = try CerealDecoder(encodedString: "k,3:wat:m,39:s,9:TestCase1:i,1:1:s,9:TestCase2:i,1:2")
+            if let dict: [TestEnum: Int] = try subject.decode("wat") {
+                XCTAssertEqual(dict[.TestCase1], 1)
+            } else {
+                XCTFail("Dictionary wasn't decoded correctly")
+            }
+        } catch let error {
+            XCTFail("Encoding failed due to error: \(error)")
+        }
+    }
+
+    func testDecoding_withIntOptionSetToIntDictionary() {
+        do {
+            let subject = try CerealDecoder(encodedString: "k,3:wat:m,23:i,1:3:i,1:1:i,1:4:i,1:2")
+            if let dict: [TestSetType: Int] = try subject.decode("wat") {
+                let testOptions: TestSetType = [TestSetType.FirstOption, TestSetType.SecondOption]
+                XCTAssertEqual(dict[testOptions], 1)
+            } else {
+                XCTFail("Dictionary wasn't decoded correctly")
+            }
+        } catch let error {
+            XCTFail("Encoding failed due to error: \(error)")
+        }
+    }
 
     // MARK: - [ABC: [XYZ]] -
 

--- a/CerealTests/CerealEncoderArrayTests.swift
+++ b/CerealTests/CerealEncoderArrayTests.swift
@@ -162,6 +162,17 @@ class CerealEncoderArrayTests: XCTestCase {
         }
     }
 
+    func testToString_withStringEnumRawRepresentableArray() {
+        do {
+            try subject.encode([TestEnum.TestCase1, TestEnum.TestCase2], forKey: "raws")
+            let result = subject.toString()
+            let expected = "k,4:raws:a,27:s,9:TestCase1:s,9:TestCase2"
+            XCTAssertEqual(result, expected)
+        } catch let error {
+            XCTFail("Encoding failed due to error: \(error)")
+        }
+    }
+
     // MARK: - Array of Dictionaries
 
     // MARK: [Bool: XXX]

--- a/CerealTests/CerealEncoderDictionaryTests.swift
+++ b/CerealTests/CerealEncoderDictionaryTests.swift
@@ -1366,6 +1366,38 @@ class CerealEncoderDictionaryTests: XCTestCase {
         }
     }
 
+    // MARK: [RawRepresentable: XXX]
+
+    func testToString_withStringEnumToIntDictionary() {
+        do {
+            var subject = CerealEncoder()
+            try subject.encode([TestEnum.TestCase1: 1, TestEnum.TestCase2: 2], forKey: "wat")
+            let result = subject.toString()
+            XCTAssertTrue(result.hasPrefix("k,3:wat:m,39:"))
+            XCTAssertTrue(result.containsSubstring("s,9:TestCase1:i,1:1"))
+            XCTAssertTrue(result.containsSubstring("s,9:TestCase2:i,1:2"))
+        } catch let error {
+            XCTFail("Encoding failed due to error: \(error)")
+        }
+    }
+
+    func testToString_withIntOptionSetToIntDictionary() {
+        do {
+            let options1: TestSetType = [TestSetType.FirstOption, TestSetType.SecondOption]
+            let options2: TestSetType = [TestSetType.ThirdOption]
+            let saveDict: [TestSetType: Int] = [options1: 1, options2: 2]
+
+            var subject = CerealEncoder()
+            try subject.encode(saveDict, forKey: "wat")
+            let result = subject.toString()
+            XCTAssertTrue(result.hasPrefix("k,3:wat:m,23:"))
+            XCTAssertTrue(result.containsSubstring("i,1:3:i,1:1"))
+            XCTAssertTrue(result.containsSubstring("i,1:4:i,1:2"))
+        } catch let error {
+            XCTFail("Encoding failed due to error: \(error)")
+        }
+    }
+
     // MARK: - Dictionaries of Arrays
 
     // MARK: [Bool: [XXX]]

--- a/CerealTests/TestTypes.swift
+++ b/CerealTests/TestTypes.swift
@@ -217,3 +217,9 @@ struct TestSetType : OptionSetType {
 }
 
 extension TestSetType: CerealRepresentable { }
+extension TestSetType: Hashable {
+    var hashValue: Int {
+        return self.rawValue.hashValue
+    }
+
+}

--- a/Example/Employee.swift
+++ b/Example/Employee.swift
@@ -16,6 +16,8 @@ struct Employee {
     init() { }
 }
 
+extension Gender: CerealRepresentable {}
+
 extension Employee: CerealType {
     private struct Keys {
         static let name = "name"
@@ -26,7 +28,7 @@ extension Employee: CerealType {
     init(decoder: CerealDecoder) throws {
         name = try decoder.decode(Keys.name) ?? ""
         age = try decoder.decode(Keys.age) ?? 0
-        gender = try decoder.decodeCereal(Keys.gender) ?? .Female
+        gender = try decoder.decode(Keys.gender) ?? .Female
     }
 
     func encodeWithCereal(inout cereal: CerealEncoder) throws {

--- a/Example/Gender.swift
+++ b/Example/Gender.swift
@@ -12,17 +12,3 @@ enum Gender: Int {
     case Female
     case Male
 }
-
-extension Gender: CerealType {
-    private struct Keys {
-        static let root = "gender"
-    }
-
-    init(decoder: CerealDecoder) throws {
-        self.init(rawValue: try decoder.decode(Keys.root) ?? Gender.Female.rawValue)!
-    }
-
-    func encodeWithCereal(inout cereal: CerealEncoder) throws {
-        try cereal.encode(rawValue, forKey: Keys.root)
-    }
-}


### PR DESCRIPTION
In #13 there was only a support for a single `RawRepresentable` values and I noticed that I cannot use same automatic support for dictionary keys. So, this pull requests covers an arrays of `RawRepresentable` types and dictionaries.
The whole point of both pull requests is to be able to add an extension to any RawRepresentable type with `CerealRepresentable` conformance in **any** swift module, not just a module where it is declared. [This](http://stackoverflow.com/questions/27390989/swift-enum-with-custom-initializer-loses-rawvalue-initializer) swift compiler bug made logic separation nearly impossible.

I have a two questions:
1. Made quite a lot of overloaded methods for `RawRepresentable`s, should I separate them into an extension?
2. Should I patch Readme.md to add a few lines about working with `RawRepresentable`?
