### PR TITLE
Fix thread safety issue 

### DIFF
--- a/Cereal/CerealSerialization.swift
+++ b/Cereal/CerealSerialization.swift
@@ -95,7 +95,12 @@ private func countCapacityBytes(array: [CoderTreeValue], inout stringMap: [Strin
         item.writeToBuffer(&result, stringMap: &stringMap)
     }
 
-    return toByteArray(result.count) + toByteArray(array.count) + result
+    let count = toByteArray(result.count)
+    let capacity = toByteArray(array.count)
+
+    result.insertContentsOf(capacity, at: 0)
+    result.insertContentsOf(count, at: 0)
+    return result
 }
 
 // MARK: encoding extensions

--- a/WatchExample Extension/InterfaceController.swift
+++ b/WatchExample Extension/InterfaceController.swift
@@ -24,7 +24,7 @@ class InterfaceController: WKInterfaceController {
         super.awakeWithContext(context)
 
         configureTable()
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "employeesUpdatedRemotely:", name: "EmployeeListUpdated", object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(InterfaceController.employeesUpdatedRemotely(_:)), name: "EmployeeListUpdated", object: nil)
     }
 
     override func willActivate() {


### PR DESCRIPTION
Caught a fatalError during mutating a private capacity info array from a several queues. So, I realized I wrote a totally thread unsafe block of code. This pull-request should fix this.
Plus added few minor changes to sample code and serialization code.
