### PR TITLE
Xcode 8 + Swift 2.3

### DIFF
--- a/Cereal.xcodeproj/xcshareddata/xcschemes/Cereal.xcscheme
+++ b/Cereal.xcodeproj/xcshareddata/xcschemes/Cereal.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Cereal.xcodeproj/xcshareddata/xcschemes/CerealWatch.xcscheme
+++ b/Cereal.xcodeproj/xcshareddata/xcschemes/CerealWatch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Cereal.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Cereal.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -53,8 +53,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Cereal/CerealSerialization.swift
+++ b/Cereal/CerealSerialization.swift
@@ -186,7 +186,7 @@ private extension CoderTreeValue {
             string.writeToBuffer(&buffer, stringMap: &stringMap)
         case let .NSURLValue(url):
             buffer.append(CerealCoderTreeValueType.NSURL.rawValue)
-            url.absoluteString.writeToBuffer(&buffer, stringMap: &stringMap)
+            url.absoluteString?.writeToBuffer(&buffer, stringMap: &stringMap)
 
         default:
             break

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -47,4 +47,12 @@ extension AppDelegate: WCSessionDelegate {
         guard let storedEmployeeData = NSUserDefaults.standardUserDefaults().objectForKey("employeeList") as? NSData else { return }
         reply["employeeList"] = storedEmployeeData
     }
+    @available(iOS 9.3, *)
+    @available(watchOSApplicationExtension 2.2, *)
+    func session(session: WCSession, activationDidCompleteWithState activationState: WCSessionActivationState, error: NSError?) {
+    }
+    func sessionDidBecomeInactive(session: WCSession) {
+    }
+    func sessionDidDeactivate(session: WCSession) {
+    }
 }

--- a/WatchExample Extension/ExtensionDelegate.swift
+++ b/WatchExample Extension/ExtensionDelegate.swift
@@ -32,4 +32,11 @@ extension ExtensionDelegate: WCSessionDelegate {
         guard message["action"] as? String == "employeesUpdated", let employeeData = message["employeeList"] as? NSData else { return }
         NSNotificationCenter.defaultCenter().postNotificationName("EmployeeListUpdated", object: nil, userInfo: ["employeeList": employeeData])
     }
+    @available(watchOSApplicationExtension 2.2, *)
+    func session(session: WCSession, activationDidCompleteWithState activationState: WCSessionActivationState, error: NSError?) {
+    }
+    func sessionDidBecomeInactive(session: WCSession) {
+    }
+    func sessionDidDeactivate(session: WCSession) {
+    }
 }


### PR DESCRIPTION
Made sources compatible with intermediate swift 2.3 version as part of swift 3 migration.
It would be great to have a separate branch the cocoapods could relate to, to support swift 2.3.
Probably we gonna need two separate tags - one for 2.2 (for xcode 7 users) and one for 2.3 (for xcode 8 users)